### PR TITLE
$statusCode is a string

### DIFF
--- a/src/Arachnid/Crawler.php
+++ b/src/Arachnid/Crawler.php
@@ -102,7 +102,7 @@ class Crawler
             $hash = $this->getPathFromUrl($url);
             $this->links[$hash]['status_code'] = $statusCode;
 
-            if ($statusCode === 200) {
+            if ($statusCode === '200') {
                 $this->extractTitleInfo($crawler, $hash);
 
                 $childLinks = array();


### PR DESCRIPTION
Since the $statusCode is a string, the condition always fails.
