### PR TITLE
fixed

### DIFF
--- a/src/Arachnid/Crawler.php
+++ b/src/Arachnid/Crawler.php
@@ -298,6 +298,8 @@ class Crawler
     {
         $base_url_trimmed = str_replace(array('http://', 'https://'), '', $this->baseUrl);
 
+        $base_url_trimmed = explode('/', $base_url_trimmed)[0];
+
         return preg_match("@http(s)?\://$base_url_trimmed@", $url) !== 1;
     }
 


### PR DESCRIPTION
The original base url extract algorithm is buggy, this commit fixes it.

For examlpe, all these urls should have the same base url:

* www.eonusihc.com/zh-TW/main -> www.eonusihc.com

* www.eonusihc.com/zh-TW -> www.eonusihc.com

* www.eonusihc.com/ -> www.eonusihc.com